### PR TITLE
Remove destructor

### DIFF
--- a/classlink-oauth2/php/OneClick.php
+++ b/classlink-oauth2/php/OneClick.php
@@ -19,15 +19,6 @@
         }
 
         /**
-         * ClassLink Oauth2 helper destructor.
-         */
-        function __destruct()
-        {
-            unset($clientId);
-            unset($clientSecret);
-        }
-
-        /**
          * Get the URL for where the client can get their access code
          * @param string $scope The scope part of the query string in the returned URL. There are 3 scopes that can be used:
          *      - profile:  Access to user identity and user specific information info.


### PR DESCRIPTION
This destructor isn't actually doing anything because the local variables `$clientId` and `$clientSecret` are not defined in this scope. 

I think the code intends to be doing the following

```php
        function __destruct()
        {
            unset($this->clientId);
            unset($this->clientSecret);
        }
```

but that shouldn't be necessary, because the members attached to the class will be unset immediately following destruction.